### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -97,6 +97,15 @@
         display: flex;
         justify-content: flex-end;
     }
+
+    .theme-toggle {
+        background: none;
+        border: none;
+        color: white;
+        font-size: 1.2rem;
+        cursor: pointer;
+        margin-left: 1rem;
+    }
 }
 
 @media screen and (max-width: 768px) {
@@ -137,6 +146,15 @@
         background-color: white;
         margin: 5px;
         transition: all 0.3s ease;
+    }
+
+    .theme-toggle {
+        background: none;
+        border: none;
+        color: white;
+        font-size: 1.2rem;
+        cursor: pointer;
+        margin-left: 1rem;
     }
     
     /* Full-screen mobile navigation */

--- a/css/styles.css
+++ b/css/styles.css
@@ -10,6 +10,25 @@
     --font-heading: 'Playfair Display', serif;
 }
 
+/* Dark mode variables */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --primary-color: #C30101;
+        --secondary-color: #FFC864;
+        --accent-color: #FFC864;
+        --light-color: #121212;
+        --dark-color: #f8f8f8;
+    }
+}
+
+html[data-theme='dark'] {
+    --primary-color: #C30101;
+    --secondary-color: #FFC864;
+    --accent-color: #FFC864;
+    --light-color: #121212;
+    --dark-color: #f8f8f8;
+}
+
 * {
     margin: 0;
     padding: 0;
@@ -122,6 +141,15 @@ nav {
 
 /* Order Online Button Styles */
 .order-online-button {
+    margin-left: 1rem;
+}
+
+.theme-toggle {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 1.2rem;
+    cursor: pointer;
     margin-left: 1rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
             <div class="order-online-button">
                 <a href="#menu" class="order-online">Order Online</a>
             </div>
+            <button class="theme-toggle" aria-label="Toggle dark mode">
+                <i class="fas fa-moon"></i>
+            </button>
             <div class="desktop-nav-container">
                 <ul class="desktop-nav">
                     <li><a href="#home">Home</a></li>

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,9 @@
 document.addEventListener('DOMContentLoaded', () => {
     // Initialize navigation
     initNavigation();
+
+    // Initialize theme toggle
+    initTheme();
     
     // Load menu items
     loadMenuItems();
@@ -473,4 +476,29 @@ function initScrollAnimations() {
             staggerObserver.observe(element);
         });
     }, 300);
+}
+
+// Theme toggle handling
+function initTheme() {
+    const toggle = document.querySelector('.theme-toggle');
+    if (!toggle) return;
+
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        toggle.innerHTML = '<i class="fas fa-sun"></i>';
+    }
+
+    toggle.addEventListener('click', () => {
+        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+        if (isDark) {
+            document.documentElement.removeAttribute('data-theme');
+            localStorage.removeItem('theme');
+            toggle.innerHTML = '<i class="fas fa-moon"></i>';
+        } else {
+            document.documentElement.setAttribute('data-theme', 'dark');
+            localStorage.setItem('theme', 'dark');
+            toggle.innerHTML = '<i class="fas fa-sun"></i>';
+        }
+    });
 }


### PR DESCRIPTION
## Summary
- add CSS variable overrides for dark theme
- style and position theme toggle button
- add toggle markup in navigation
- implement theme toggle logic with localStorage persistence

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e3edfca0832985fc99ad687876c0