### PR TITLE
Fix dark mode toggle

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,14 +40,31 @@ html[data-theme='dark'] body {
     color: var(--dark-color);
 }
 
-html[data-theme='dark'] .nav-links a,
-html[data-theme='dark'] .theme-toggle {
+
+html[data-theme='light'] {
+    --primary-color: #C30101;
+    --secondary-color: #FFD454;
+    --accent-color: #FFD454;
+    --highlight-color: #FFDE7D;
+    --light-color: #f8f8f8;
+    --dark-color: #333;
+    --light-text-color: #ffffff;
+}
+
+html[data-theme='light'] body {
+    background-color: var(--light-color);
     color: var(--dark-color);
 }
 
-html[data-theme='dark'] .burger div {
+html[data-theme='light'] .nav-links a,
+html[data-theme='light'] .theme-toggle {
+    color: var(--dark-color);
+}
+
+html[data-theme='light'] .burger div {
     background-color: var(--dark-color);
 }
+
 
 * {
     margin: 0;

--- a/js/app.js
+++ b/js/app.js
@@ -484,21 +484,20 @@ function initTheme() {
     if (!toggle) return;
 
     const stored = localStorage.getItem('theme');
-    if (stored === 'dark') {
-        document.documentElement.setAttribute('data-theme', 'dark');
-        toggle.innerHTML = '<i class="fas fa-sun"></i>';
+    if (stored === 'dark' || stored === 'light') {
+        document.documentElement.setAttribute('data-theme', stored);
+        toggle.innerHTML = stored === 'dark'
+            ? '<i class="fas fa-sun"></i>'
+            : '<i class="fas fa-moon"></i>';
     }
 
     toggle.addEventListener('click', () => {
-        const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        if (isDark) {
-            document.documentElement.removeAttribute('data-theme');
-            localStorage.removeItem('theme');
-            toggle.innerHTML = '<i class="fas fa-moon"></i>';
-        } else {
-            document.documentElement.setAttribute('data-theme', 'dark');
-            localStorage.setItem('theme', 'dark');
-            toggle.innerHTML = '<i class="fas fa-sun"></i>';
-        }
+        const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        const next = current === 'dark' ? 'light' : 'dark';
+        document.documentElement.setAttribute('data-theme', next);
+        localStorage.setItem('theme', next);
+        toggle.innerHTML = next === 'dark'
+            ? '<i class="fas fa-sun"></i>'
+            : '<i class="fas fa-moon"></i>';
     });
 }


### PR DESCRIPTION
## Summary
- maintain a `data-theme` attribute for both light and dark themes
- add CSS rules for the explicit light theme
- update theme toggle logic to switch between 'dark' and 'light'

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846c9fb0b80832996b31e0222071455